### PR TITLE
API: path args only, match command order for bspatch

### DIFF
--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -50,7 +50,7 @@ function bsdiff(old::IOorString, new::IOorString)
     return tmp
 end
 
-function bspatch(old::IO, patch::IO, new::IO)
+function bspatch(old::IO, new::IO, patch::IO)
     hdr = String(read(patch, ncodeunits(HEADER)))
     hdr == HEADER || error("corrupt bsdiff patch")
     new_size = Int(int_io(read(patch, Int64)))
@@ -61,13 +61,13 @@ function bspatch(old::IO, patch::IO, new::IO)
 end
 
 # allow any subset of arguments to be strings or IO objects
-bspatch(old::AbstractString, patch::IOorString, new::IOorString) =
-    open(old->bspatch(old, patch, new), old)
-bspatch(old::IO, patch::AbstractString, new::IOorString) =
-    open(patch->bspatch(old, patch, new), patch)
+bspatch(old::AbstractString, new::IOorString, patch::IOorString) =
+    open(old->bspatch(old, new, patch), old)
+bspatch(old::IO, new::IOorString, patch::AbstractString) =
+    open(patch->bspatch(old, new, patch), patch)
 
-function bspatch(old::IO, patch::IO, new::AbstractString)
-    try open(new->bspatch(old, patch, new), new, write=true)
+function bspatch(old::IO, new::AbstractString, patch::IO)
+    try open(new->bspatch(old, new, patch), new, write=true)
     catch
         rm(new, force=true)
         rethrow()
@@ -77,7 +77,7 @@ end
 
 function bspatch(old::IOorString, patch::IOorString)
     tmp, new = mktemp()
-    try bspatch(old, patch, new)
+    try bspatch(old, new, patch)
     catch
         close(new)
         rm(tmp, force=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,29 @@ import bsdiff_jll
 const test_data = artifact"test_data"
 
 @testset "BSDiff" begin
+    @testset "API coverage" begin
+        # create new, old and reference patch files
+        dir = mktempdir()
+        old_file = joinpath(dir, "old")
+        new_file = joinpath(dir, "new")
+        write(old_file, "Goodbye, world.")
+        write(new_file, "Hello, world!")
+        # check API passing only two paths
+        @testset "2-arg API" begin
+            patch_file = bsdiff(old_file, new_file)
+            new_file′ = bspatch(old_file, patch_file)
+            @test read(new_file′, String) == "Hello, world!"
+        end
+        # check API passing all three paths
+        @testset "3-arg API" begin
+            patch_file = joinpath(dir, "patch")
+            new_file′ = joinpath(dir, "new′")
+            bsdiff(old_file, new_file, patch_file)
+            bspatch(old_file, new_file′, patch_file)
+            @test read(new_file′, String) == "Hello, world!"
+        end
+        rm(dir, recursive=true, force=true)
+    end
     @testset "registry data" begin
         registry_data = joinpath(test_data, "registry")
         old = joinpath(registry_data, "before.tar")


### PR DESCRIPTION
This PR limits the `bsdiff` and `bspatch` API entry points to only supporting path (`AbstractString`) arguments. In principle, we'd like to support arbitray IO objects like the previous API was supposed to, but due to puzzling interactions with the `TranscodingStreams` layer, that part of the API was broken (see https://github.com/JuliaIO/TranscodingStreams.jl/issues/95). This was discovered when writing tests for more of the API. Instead, this change limits the API to path arguments and adds tests for the full API surface.