### PR TITLE
fix bug in original bsdiff program use of memcmp for string compare

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,10 @@ const test_data = artifact"test_data"
             diff = sprint() do io
                 BSDiff.write_diff(io, old_data, new_data)
             end |> codeunits
-            @test read(ref) == diff
+            # this test is unequal because the original bsdiff code is buggy:
+            # it uses `memcmp(old, new, min(length(old), length(new)))` whereas
+            # it should break memcmp ties by comparing the length of old & new
+            @test read(ref) ≠ diff
             # test that applying reference patch to old produces new
             new_data′ = open(ref) do patch
                 sprint() do new


### PR DESCRIPTION
The original `bsdiff` program uses `memcmp(old, new, min(length(old), length(new)))` to lexicographically compare strings, but this is wrong in the case where they are equal up to the length of the shorter of the two strings. When `memcmp` returns zero, the tie should be broken by comparing the lengths of the strings, the shorter one coming first. This version makes slightly better patches, but the difference is rarely very significant. The patch format is unchanged, so patches produced by the Julia library can be consumed by the command and vice versa, but they no longer produce identical patches (the compression might have been different anyway).