### PR TITLE
avoid conflict w/ SuffixArrays: rename suffixsort => bssort

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Note that the optional argument is the middle argument, which is a bit unusual
 in a Julia API, but which allows the argument order when passing all three paths
 to be the same as the `bspatch` command.
 
-### suffixsort
+### bssort
 
 ```julia
-suffixsort(old, [ suffix_file ]) -> suffix_file
+bssort(old, [ suffix_file ]) -> suffix_file
 ```
 Save the suffix array for the file `old` into the file `suffix_file`. All
 arguments are strings. If no `suffix_file` argument is given, the suffix array

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,13 +29,13 @@ const test_data = artifact"test_data"
             bspatch(old_file, new_file′, patch_file)
             @test read(new_file′, String) == "Hello, world!"
         end
-        @testset "suffixsort API" begin
-            suffixsort(old_file, suffix_file)
+        @testset "bssort API" begin
+            bssort(old_file, suffix_file)
             patch_file = bsdiff((old_file, suffix_file), new_file)
             new_file′ = bspatch(old_file, patch_file)
             @test read(new_file′, String) == "Hello, world!"
             # test that tempfile API makes the same file
-            suffix_file′ = suffixsort(old_file)
+            suffix_file′ = bssort(old_file)
             @test read(suffix_file) == read(suffix_file′)
         end
         rm(dir, recursive=true, force=true)


### PR DESCRIPTION
I decided that exporting a different function with the same name as the SuffixArrays.suffixsort function which is also exported and which does something related was a bad move. In keeping with the `bsxxx` naming scheme of this package, this name is now `bssort` instead.