### PR TITLE
rename: bssort => bsindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,16 @@ Note that the optional argument is the middle argument, which is a bit unusual
 in a Julia API, but which allows the argument order when passing all three paths
 to be the same as the `bspatch` command.
 
-### bssort
+### bsindex
 
 ```julia
-bssort(old, [ suffix_file ]) -> suffix_file
+bsindex(old, [ index ]) -> index
 ```
-Save the suffix array for the file `old` into the file `suffix_file`. All
-arguments are strings. If no `suffix_file` argument is given, the suffix array
-is saved to a temporary file and its path is returned.
-
-The path of the suffix file can be passed to `bsdiff` to speed up the diff
-computation (by loading the sorted suffix array rather than computing it), by
-passing `(old, suffix_file)` as the first argument instead of just `old`.
+Save index data (currently a sorted suffix array) for the file `old` into the
+file `index`. All arguments are strings. If no `index` argument is given, the
+index data is saved to a temporary file whose path is returned. The path of the
+index file can be passed to `bsdiff` to speed up the diff computation by passing
+`(old, index)` as the first argument instead of just `old`.
 
 <!-- END: copied from inline doc strings -->
 

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -1,6 +1,6 @@
 module BSDiff
 
-export bsdiff, bspatch, bssort
+export bsdiff, bspatch, bsindex
 
 using SuffixArrays
 using TranscodingStreams, CodecBzip2
@@ -55,27 +55,25 @@ function bspatch(old::AbstractString, patch::AbstractString)
 end
 
 """
-    bssort(old, [ suffix_file ]) -> suffix_file
+    bsindex(old, [ index ]) -> index
 
-Save the suffix array for the file `old` into the file `suffix_file`. All
-arguments are strings. If no `suffix_file` argument is given, the suffix array
-is saved to a temporary file and its path is returned.
-
-The path of the suffix file can be passed to `bsdiff` to speed up the diff
-computation (by loading the sorted suffix array rather than computing it), by
-passing `(old, suffix_file)` as the first argument instead of just `old`.
+Save index data (currently a sorted suffix array) for the file `old` into the
+file `index`. All arguments are strings. If no `index` argument is given, the
+index data is saved to a temporary file whose path is returned. The path of the
+index file can be passed to `bsdiff` to speed up the diff computation by passing
+`(old, index)` as the first argument instead of just `old`.
 """
-function bssort(old::AbstractString, suffix_file::AbstractString)
-    suffixsort_core(read(old), suffix_file, open(suffix_file, write=true))
+function bsindex(old::AbstractString, index::AbstractString)
+    bsindex_core(read(old), index, open(index, write=true))
 end
 
-function bssort(old::AbstractString)
-    suffixsort_core(read(old), mktemp()...)
+function bsindex(old::AbstractString)
+    bsindex_core(read(old), mktemp()...)
 end
 
 # common code for API entry points
 
-const HEADER = "ENDSLEY/BSDIFF43"
+const PATCH_HEADER = "ENDSLEY/BSDIFF43"
 
 function bsdiff_core(
     old_data::AbstractVector{UInt8},
@@ -85,7 +83,7 @@ function bsdiff_core(
     patch_io::IO,
 )
     try
-        write(patch_io, HEADER)
+        write(patch_io, PATCH_HEADER)
         write(patch_io, int_io(Int64(length(new_data))))
         io = TranscodingStream(Bzip2Compressor(), patch_io)
         write_diff(io, old_data, new_data, suffixes)
@@ -106,8 +104,8 @@ function bspatch_core(
     patch_io::IO,
 )
     try
-        hdr = String(read(patch_io, ncodeunits(HEADER)))
-        hdr == HEADER || error("corrupt bsdiff patch")
+        hdr = String(read(patch_io, ncodeunits(PATCH_HEADER)))
+        hdr == PATCH_HEADER || error("corrupt bsdiff patch")
         new_size = Int(int_io(read(patch_io, Int64)))
         io = TranscodingStream(Bzip2Decompressor(), patch_io)
         apply_patch(old_data, io, new_io, new_size)
@@ -121,21 +119,21 @@ function bspatch_core(
     return new
 end
 
-function suffixsort_core(
+function bsindex_core(
     old_data::AbstractVector{UInt8},
-    suffix_file::AbstractString,
-    suffix_io::IO,
+    index::AbstractString,
+    index_io::IO,
 )
     try
         suffixes = suffixsort(old_data, 0)
-        write(suffix_io, suffixes)
+        write(index_io, suffixes)
     catch
-        close(suffix_io)
-        rm(suffix_file, force=true)
+        close(index_io)
+        rm(index, force=true)
         rethrow()
     end
-    close(suffix_io)
-    return suffix_file
+    close(index_io)
+    return index
 end
 
 ## loading data and suffixes ##
@@ -153,7 +151,7 @@ function data_and_suffixes((data_path, suffix_path)::NTuple{2,AbstractString})
         unit == 2 ? UInt16 :
         unit == 4 ? UInt32 :
         unit == 8 ? UInt64 :
-        error("invalid index type size for suffix file: $unit")
+        error("invalid unit size for suffix file: $unit")
     return data, read!(suffix_path, Vector{T}(undef, round(Int, size/unit)))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,13 +29,13 @@ const test_data = artifact"test_data"
             bspatch(old_file, new_file′, patch_file)
             @test read(new_file′, String) == "Hello, world!"
         end
-        @testset "bssort API" begin
-            bssort(old_file, suffix_file)
+        @testset "bsindex API" begin
+            bsindex(old_file, suffix_file)
             patch_file = bsdiff((old_file, suffix_file), new_file)
             new_file′ = bspatch(old_file, patch_file)
             @test read(new_file′, String) == "Hello, world!"
             # test that tempfile API makes the same file
-            suffix_file′ = bssort(old_file)
+            suffix_file′ = bsindex(old_file)
             @test read(suffix_file) == read(suffix_file′)
         end
         rm(dir, recursive=true, force=true)


### PR DESCRIPTION
Another rename to the more generic `bsindex` which merely promises to save an index of some kind to the file given by the `index` argument. ~In the future, this could include more than just the sorted suffix array, although at that point it would need a header.~ The saved file now also includes a header so that if we decide to change the format of the index, it will be obvious.