### PR TITLE
try using LCP data to speed up diff generation

### DIFF
--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -196,13 +196,14 @@ int_io(x::Signed) = ifelse(x == abs(x), x, typemin(x) - x)
 Return lexicographic order and length of common prefix.
 """
 function strcmplen(p::Ptr{UInt8}, m::Int, q::Ptr{UInt8}, n::Int)
-    i = j = l = x = 0
-    while i < m && j < n
-        x = cmp(unsafe_load(p+i), unsafe_load(q+j))
-        x ≠ 0 && break
-        i += 1; j += 1; l += 1
+    i = 0
+    while i < min(m, n)
+        a = unsafe_load(p + i)
+        b = unsafe_load(q + i)
+        a ≠ b && return (a - b) % Int8, i
+        i += 1
     end
-    return ifelse(x == 0, cmp(m, n), x), l
+    return (m - n) % Int8, i
 end
 
 """
@@ -232,7 +233,8 @@ function prefix_search(
         x = cmp(c, lcp)
         if dir == 0 || x == 0
             # need to look at more of the needle
-            dir, l = strcmplen(new_p+c, new_n-c, old_p+s+c, old_n-s-c)
+            d, l = strcmplen(new_p+c, new_n-c, old_p+s+c, old_n-s-c)
+            dir = sign(d)
             lcp += l
             dir == 0 && return (s+1, lcp)
         end

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -364,4 +364,79 @@ function apply_patch(
     return n
 end
 
+## IO type that run-length encodes zero bytes ##
+
+mutable struct ZrleIO{T<:IO} <: IO
+    stream::T
+    zeros::UInt64
+end
+ZrleIO(io::IO) = ZrleIO{typeof(io)}(io, 0)
+
+Base.eof(io::ZrleIO) = io.zeros == 0 && eof(io.stream)
+Base.isopen(io::ZrleIO) = isopen(io.stream)
+
+function flush_zeros(io::ZrleIO)
+    if io.zeros > 0
+        write(io.stream, 0x0)
+        write_leb128(io.stream, io.zeros-1)
+        io.zeros = 0
+    end
+end
+
+function Base.flush(io::ZrleIO)
+    flush_zeros(io)
+    flush(io.stream)
+end
+
+function Base.close(io::ZrleIO)
+    isreadonly(io.stream) || flush_zeros(io)
+    close(io.stream)
+end
+
+function Base.write(io::ZrleIO, byte::UInt8)
+    if byte == 0
+        io.zeros += 1
+    else
+        flush_zeros(io)
+        write(io.stream, byte)
+    end
+    return 1
+end
+
+function Base.read(io::ZrleIO, ::Type{UInt8})
+    if io.zeros > 0
+        io.zeros -= 1
+        return 0x0
+    end
+    byte = read(io.stream, UInt8)
+    if byte == 0
+        io.zeros = read_leb128(io.stream, typeof(io.zeros))
+    end
+    return byte
+end
+
+## variable length integer output ##
+
+function write_leb128(io::IO, n::Unsigned)
+    while true
+        byte::UInt8 = n & 0x7f
+        more = (n >>= 7) != 0
+        byte |= UInt8(more) << 7
+        write(io, byte)
+        more || break
+    end
+end
+
+function read_leb128(io::IO, ::Type{T}) where {T<:Unsigned}
+    n::T = zero(T)
+    shift = 0
+    while true
+       byte = read(io, UInt8)
+       n |= T(byte & 0x7f) << shift
+       (byte & 0x80) == 0 && break
+       shift += 7
+    end
+    return n
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,5 +80,11 @@ const test_data = artifact"test_data"
                 @test new_data == read(new′)
             end
         end
+        @testset "timing" begin
+            index = @time BSDiff.generate_index(old_data)
+            @time BSDiff.write_diff(devnull, old_data, new_data, index)
+            @time BSDiff.write_diff(devnull, old_data, new_data, index)
+            @time BSDiff.write_diff(devnull, old_data, new_data, index)
+        end
     end
 end


### PR DESCRIPTION
Unfortunately, this was an unsuccessful experiment. Here are the timings without using the LCP data:
```
2.181186 seconds (79 allocations: 1.542 GiB, 9.02% gc time)
0.379120 seconds (104.20 k allocations: 4.885 MiB)
0.311887 seconds (13.30 k allocations: 207.953 KiB)
0.311125 seconds (13.30 k allocations: 207.953 KiB)
```
Here are the timings using the LCP data:
```
6.357530 seconds (75 allocations: 1.691 GiB, 4.06% gc time)
0.419969 seconds (104.20 k allocations: 4.885 MiB)
0.324098 seconds (13.30 k allocations: 207.953 KiB)
0.324188 seconds (13.30 k allocations: 207.953 KiB)
```
So the index generation is much slower, as expected, but the diff also got a bit slower. I tried this with the LCP data interleaved with the suffix array data (as it is now) and with it strictly after the suffix array data and neither was notably better.