### PR TITLE
simpler LCP: avoiding rescanning common lo/hi prefix

### DIFF
--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -364,4 +364,79 @@ function apply_patch(
     return n
 end
 
+## IO type that run-length encodes zero bytes ##
+
+mutable struct ZrleIO{T<:IO} <: IO
+    stream::T
+    zeros::UInt64
+end
+ZrleIO(io::IO) = ZrleIO{typeof(io)}(io, 0)
+
+Base.eof(io::ZrleIO) = io.zeros == 0 && eof(io.stream)
+Base.isopen(io::ZrleIO) = isopen(io.stream)
+
+function flush_zeros(io::ZrleIO)
+    if io.zeros > 0
+        write(io.stream, 0x0)
+        write_leb128(io.stream, io.zeros-1)
+        io.zeros = 0
+    end
+end
+
+function Base.flush(io::ZrleIO)
+    flush_zeros(io)
+    flush(io.stream)
+end
+
+function Base.close(io::ZrleIO)
+    isreadonly(io.stream) || flush_zeros(io)
+    close(io.stream)
+end
+
+function Base.write(io::ZrleIO, byte::UInt8)
+    if byte == 0
+        io.zeros += 1
+    else
+        flush_zeros(io)
+        write(io.stream, byte)
+    end
+    return 1
+end
+
+function Base.read(io::ZrleIO, ::Type{UInt8})
+    if io.zeros > 0
+        io.zeros -= 1
+        return 0x0
+    end
+    byte = read(io.stream, UInt8)
+    if byte == 0
+        io.zeros = read_leb128(io.stream, typeof(io.zeros))
+    end
+    return byte
+end
+
+## variable length integer output ##
+
+function write_leb128(io::IO, n::Unsigned)
+    while true
+        byte::UInt8 = n & 0x7f
+        more = (n >>= 7) != 0
+        byte |= UInt8(more) << 7
+        write(io, byte)
+        more || break
+    end
+end
+
+function read_leb128(io::IO, ::Type{T}) where {T<:Unsigned}
+    n::T = zero(T)
+    shift = 0
+    while true
+       byte = read(io, UInt8)
+       n |= T(byte & 0x7f) << shift
+       (byte & 0x80) == 0 && break
+       shift += 7
+    end
+    return n
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,5 +80,11 @@ const test_data = artifact"test_data"
                 @test new_data == read(new′)
             end
         end
+        @testset "timing" begin
+            index = @time BSDiff.generate_index(old_data)
+            @time BSDiff.write_diff(devnull, old_data, new_data, index)
+            @time BSDiff.write_diff(devnull, old_data, new_data, index)
+            @time BSDiff.write_diff(devnull, old_data, new_data, index)
+        end
     end
 end


### PR DESCRIPTION
This is a simpler alternative to https://github.com/JuliaIO/BSDiff.jl/pull/18 (which unfortunately did not speed up patch generation). Instead of using a precomputed LCP array, it just skips whatever the common prefix shared between the needle and the lo/hi search points. This means that once you know that the needle matches both the left and right endpoints of the search window, we can skip rescanning that much of the strings when doing comparisons. This does improve the timings a bit, especially when we're not doing ZRLE compression so that there are a substantial number of strings to search and be searched with a lot of common prefix (all those zeros). Timings with this patch:
```
raw index gen: 1.837114 seconds (79 allocations: 1.542 GiB, 12.43% gc time)
raw patch gen: 0.328058 seconds (104.21 k allocations: 4.885 MiB)
raw patch gen: 0.254924 seconds (13.30 k allocations: 207.953 KiB)
raw patch gen: 0.253012 seconds (13.30 k allocations: 207.953 KiB)
zrl index gen: 1.591293 seconds (1.97 M allocations: 640.254 MiB, 8.86% gc time)
zrl patch gen: 0.189107 seconds (161.85 k allocations: 7.394 MiB)
zrl patch gen: 0.095359 seconds (12.35 k allocations: 193.047 KiB)
zrl patch gen: 0.096612 seconds (12.35 k allocations: 193.047 KiB)
```
Versus timings on https://github.com/JuliaIO/BSDiff.jl/pull/13:
```
raw index gen: 1.861430 seconds (79 allocations: 1.542 GiB, 11.51% gc time)
raw patch gen: 0.402050 seconds (104.21 k allocations: 4.885 MiB)
raw patch gen: 0.334669 seconds (13.30 k allocations: 207.953 KiB)
raw patch gen: 0.335994 seconds (13.30 k allocations: 207.953 KiB)
zrl index gen: 1.568364 seconds (1.97 M allocations: 640.254 MiB, 7.28% gc time)
zrl patch gen: 0.208554 seconds (165.16 k allocations: 7.519 MiB)
zrl patch gen: 0.099151 seconds (12.35 k allocations: 193.047 KiB)
zrl patch gen: 0.099072 seconds (12.35 k allocations: 193.047 KiB)
```
Index (suffix array) generation is the same (it's unchanged). Patch generation is 25% faster for raw tarball data with lots of long sequences of zero bytes. Patch generation for ZRLE-preprocessed tarballs is 4% faster, which is not huge but not nothing. So overall this seems like a win.