### PR TITLE
implement 'sparse' patch format

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Stefan Karpinski <stefan@karpinski.org>"]
 version = "1.0.0"
 
 [deps]
+BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
 CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
 SuffixArrays = "24f65c1e-0a10-5d3d-8a1f-a83399f3fced"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -14,6 +14,7 @@ abstract type Patch end
 
 include("classic.jl")
 include("endsley.jl")
+include("sparse.jl")
 
 # format names, patch types, auto detection
 
@@ -21,6 +22,7 @@ const DEFAULT_FORMAT = :classic
 const FORMATS = Dict(
     :classic => ClassicPatch,
     :endsley => EndsleyPatch,
+    :sparse  => SparsePatch,
 )
 
 function patch_type(format::Symbol)

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -180,7 +180,6 @@ function bsdiff_core(
     patch_file::AbstractString,
     patch_io::IO,
 )
-    patch_io = BufferedOutputStream(patch_io)
     try
         write(patch_io, format_magic(format))
         patch = write_start(format, patch_io, old_data, new_data)
@@ -203,7 +202,6 @@ function bspatch_core(
     patch_io::IO,
 )
     new_io = BufferedOutputStream(new_io)
-    patch_io = BufferedInputStream(patch_io)
     try
         MAGIC = format_magic(format)
         magic = String(read(patch_io, ncodeunits(MAGIC)))

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -15,6 +15,7 @@ abstract type Patch end
 include("classic.jl")
 include("endsley.jl")
 include("sparse.jl")
+include("zrle.jl")
 
 # format names, patch types, auto detection
 

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -184,7 +184,7 @@ function bsdiff_core(
     try
         write(patch_io, format_magic(format))
         patch = write_start(format, patch_io, old_data, new_data)
-        @time generate_patch(patch, old_data, new_data, index)
+        generate_patch(patch, old_data, new_data, index)
         close(patch)
     catch
         close(patch_io)

--- a/src/leb128.jl
+++ b/src/leb128.jl
@@ -1,0 +1,23 @@
+# variable-length integer I/O
+
+function write_leb128(io::IO, n::Unsigned)
+    while true
+        byte::UInt8 = n & 0x7f
+        more = (n >>= 7) != 0
+        byte |= UInt8(more) << 7
+        write(io, byte)
+        more || break
+    end
+end
+
+function read_leb128(io::IO, ::Type{T}) where {T<:Unsigned}
+    n::T = zero(T)
+    shift = 0
+    while true
+       byte = read(io, UInt8)
+       n |= T(byte & 0x7f) << shift
+       (byte & 0x80) == 0 && break
+       shift += 7
+    end
+    return n
+end

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -1,0 +1,110 @@
+include("leb128.jl")
+
+struct SparsePatch{T<:IO} <: Patch
+    io::T
+    new_size::Int64
+end
+SparsePatch(io::IO) = SparsePatch(io, typemax(Int64))
+
+format_magic(::Type{SparsePatch}) = "BSDiff.jl/Sparse\0"
+
+function write_start(
+    ::Type{SparsePatch},
+    patch_io::IO,
+    old_data::AbstractVector{UInt8},
+    new_data::AbstractVector{UInt8};
+    codec::Codec = Bzip2Compressor(),
+)
+    new_size = length(new_data)
+    write_leb128(patch_io, UInt64(new_size))
+    SparsePatch(patch_io, new_size)
+end
+
+function read_start(
+    ::Type{SparsePatch},
+    patch_io::IO;
+)
+    new_size = Int(read_leb128(patch_io, UInt64))
+    SparsePatch(patch_io, new_size)
+end
+
+Base.close(patch::SparsePatch) = close(patch.io)
+
+function encode_control(
+    patch::SparsePatch,
+    diff_size::Int,
+    copy_size::Int,
+    skip_size::Int,
+)
+    write_leb128(patch.io, UInt64(diff_size))
+    write_leb128(patch.io, UInt64(copy_size))
+    skip_size = (abs(skip_size) << 1) | (skip_size < 0)
+    write_leb128(patch.io, UInt64(skip_size))
+end
+
+function decode_control(patch::SparsePatch)
+    eof(patch.io) && return nothing
+    diff_size = Int(read_leb128(patch.io, UInt64))
+    copy_size = Int(read_leb128(patch.io, UInt64))
+    skip_size = read_leb128(patch.io, UInt64)
+    neg = isodd(skip_size)
+    skip_size = (neg ? -1 : 1)*Int(skip_size >>> 1)
+    return diff_size, copy_size, skip_size
+end
+
+function encode_diff(
+    patch::SparsePatch,
+    diff_size::Int,
+    new::AbstractVector{UInt8}, new_pos::Int,
+    old::AbstractVector{UInt8}, old_pos::Int,
+)
+    for i = 1:diff_size
+        d = new[new_pos + i] - old[old_pos + i]
+        d == 0 && continue
+        write(patch.io, d)
+        write_leb128(patch.io, UInt64(i-1))
+    end
+    write(patch.io, 0x0)
+end
+
+function decode_diff(
+    patch::SparsePatch,
+    diff_size::Int,
+    new::IO,
+    old::AbstractVector{UInt8},
+    old_pos::Int,
+)
+    i = 1
+    while true
+        d = read(patch.io, UInt8)
+        d == 0 && break
+        j = Int(read_leb128(patch.io, UInt64)+1)
+        while i < j
+            i += write(new, old[old_pos + i])
+        end
+        i += write(new, old[old_pos + i] + d)
+    end
+    while i ≤ diff_size
+        i += write(new, old[old_pos + i])
+    end
+end
+
+function encode_data(
+    patch::SparsePatch,
+    copy_size::Int,
+    new::AbstractVector{UInt8}, pos::Int,
+)
+    for i = 1:copy_size
+        write(patch.io, new[pos + i])
+    end
+end
+
+function decode_data(
+    patch::SparsePatch,
+    copy_size::Int,
+    new::IO,
+)
+    for i = 1:copy_size
+        write(new, read(patch.io, UInt8))
+    end
+end

--- a/src/zrle.jl
+++ b/src/zrle.jl
@@ -1,0 +1,76 @@
+## IO type that run-length encodes zero bytes ##
+
+mutable struct ZRLE{T<:IO} <: IO
+    stream::T
+    zeros::UInt64
+end
+ZRLE(io::IO) = ZRLE{typeof(io)}(io, 0)
+
+Base.eof(io::ZRLE) = io.zeros == 0 && eof(io.stream)
+Base.close(io::ZRLE) = close(io.stream)
+
+function Base.read(io::ZRLE, ::Type{UInt8})
+    zeros = io.zeros
+    if zeros == 0
+        byte = read(io.stream, UInt8)
+        byte ≠ 0 && return byte
+        zeros += 1
+        while !eof(io.stream) && Base.peek(io.stream) == 0
+            read(io.stream, UInt8)
+            zeros += 1
+        end
+        io.zeros = zeros
+        return 0x0
+    end
+    n = zeros - 1
+    # compute one LEB128 byte
+    byte = (n % UInt8) & 0x7f
+    n >>= 7
+    byte |= UInt8(n > 0) << 7
+    io.zeros = n + (n > 0)
+    return byte
+end
+
+function Base.write(io::ZRLE, byte::UInt8)
+    zeros = io.zeros
+    if zeros == 0
+        write(io.stream, byte)
+        io.zeros = byte == 0
+    else
+        # decode LEB128 one byte at a time
+        # leading bit indicates shift position
+        # trailing bits are the value so far
+        shift = 63 - leading_zeros(zeros)
+        zeros &= ((1 << shift) - 1)
+        zeros |= UInt64(byte) << shift
+        if byte & 0x80 > 0
+            io.zeros = zeros
+        else
+            for _ = 1:zeros
+                write(io.stream, 0x0)
+            end
+            io.zeros = 0
+        end
+    end
+    return 1
+end
+
+function read_zrle(path::AbstractString)
+    buf = IOBuffer(sizehint = filesize(path))
+    open(path) do file
+        while !eof(file)
+            byte = read(file, UInt8)
+            write(buf, byte)
+            if byte == 0
+                n = UInt64(0)
+                while byte == 0 && !eof(file)
+                    byte = read(file, UInt8)
+                    n += byte == 0
+                end
+                write_leb128(buf, n)
+                byte ≠ 0 && write(buf, byte)
+            end
+        end
+    end
+    return take!(buf)
+end

--- a/src/zrle.jl
+++ b/src/zrle.jl
@@ -58,6 +58,7 @@ end
 function read_zrle(path::AbstractString)
     buf = IOBuffer(sizehint = filesize(path))
     open(path) do file
+        file = BufferedInputStream(file)
         while !eof(file)
             byte = read(file, UInt8)
             write(buf, byte)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,11 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
                 patch = @time bsdiff((old_zrl, index), new_zrl, format = format)
                 new_zrl′ = bspatch(old_zrl, patch)
                 @test read(new_zrl) == read(new_zrl′)
+                @show filesize(patch)
+                for (cmd, ext) in [("zstd", "zst"), ("bzip2", "bz2"), ("xz", "xz")]
+                    run(`$cmd -qk9 $patch`)
+                    @show cmd, filesize("$patch.$ext")
+                end
             end
             # # eliminate I/O overhead
             # old_zrl_data = read(old_zrl)
@@ -100,9 +105,9 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
             new′ = bspatch(old, patch)
             @test read(new) == read(new′)
             @show filesize(patch)
-            for (compress, ext) in [("zstd", "zst"), ("bzip2", "bz2"), ("xz", "xz")]
-                run(`$compress -qk9 $patch`)
-                @show compress, filesize("$patch.$ext")
+            for (cmd, ext) in [("zstd", "zst"), ("bzip2", "bz2"), ("xz", "xz")]
+                run(`$cmd -qk9 $patch`)
+                @show cmd, filesize("$patch.$ext")
             end
         end
         @testset "low-level API" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
         suffix_file = joinpath(dir, "suffixes")
         write(old_file, "Goodbye, world.")
         write(new_file, "Hello, world!")
-        for format in (nothing, :classic, :endsley)
+        for format in [nothing; FORMATS]
             fmt = format == nothing ? [] : [:format => format]
             # check API passing only two paths
             @testset "2-arg API" begin
@@ -86,7 +86,7 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
                     (:classic, bsdiff_classic_jll),
                     (:endsley, bsdiff_endsley_jll),
                 ]
-                @testset "high-level API" begin
+                @testset "compatibility" begin
                     # test that bspatch command accepts patches we generate
                     patch = bsdiff(old, new, format = format)
                     new′ = tempname()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
         old_data = read(old)
         new_data = read(new)
         @testset "zrl data" begin
+            println("[ ZRL data ]")
             old_zrl = "$old.zrl"
             new_zrl = "$new.zrl"
             write(old_zrl, BSDiff.read_zrle(old))
@@ -70,25 +71,26 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
                 new_zrl′ = bspatch(old_zrl, patch)
                 @test read(new_zrl) == read(new_zrl′)
             end
-            # eliminate I/O overhead
-            old_zrl_data = read(old_zrl)
-            new_zrl_data = read(new_zrl)
-            index_data = BSDiff.generate_index(old_zrl_data)
-            for PatchType in [BSDiff.ClassicPatch, BSDiff.EndsleyPatch, BSDiff.SparsePatch]
-                println("$PatchType generation to devnull:")
-                patch = PatchType(devnull, length(new_zrl_data))
-                @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
-                @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
-                @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
-                println("$PatchType generation to IOBuffer:")
-                diff = sprint() do io
-                    patch = PatchType(io, length(new_zrl_data))
-                    @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
-                    @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
-                    @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
-                end |> codeunits
-            end
+            # # eliminate I/O overhead
+            # old_zrl_data = read(old_zrl)
+            # new_zrl_data = read(new_zrl)
+            # index_data = BSDiff.generate_index(old_zrl_data)
+            # for PatchType in [BSDiff.ClassicPatch, BSDiff.EndsleyPatch, BSDiff.SparsePatch]
+            #     println("$PatchType generation to devnull:")
+            #     patch = PatchType(devnull, length(new_zrl_data))
+            #     @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+            #     @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+            #     @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+            #     println("$PatchType generation to IOBuffer:")
+            #     diff = sprint() do io
+            #         patch = PatchType(io, length(new_zrl_data))
+            #         @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+            #         @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+            #         @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+            #     end |> codeunits
+            # end
         end
+        println("[ non-ZRL data ]")
         @testset "hi-level API" for format in FORMATS
             @show format
             index = bsindex(old)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,7 +67,7 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
             @test read(new) == read(new′)
             @show filesize(patch)
             for (cmd, ext) in [("zstd", "zst"), ("bzip2", "bz2"), ("xz", "xz")]
-                run(`$cmd -qk9 $patch`)
+                @time run(`$cmd -qk9 $patch`)
                 @show cmd, filesize("$patch.$ext")
             end
         end
@@ -87,7 +87,7 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
                 @test read(new_zrl) == read(new_zrl′)
                 @show filesize(patch)
                 for (cmd, ext) in [("zstd", "zst"), ("bzip2", "bz2"), ("xz", "xz")]
-                    run(`$cmd -qk9 $patch`)
+                    @time run(`$cmd -qk9 $patch`)
                     @show cmd, filesize("$patch.$ext")
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,39 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
         ref = joinpath(registry_data, "reference.diff")
         old_data = read(old)
         new_data = read(new)
+        @testset "zrl data" begin
+            old_zrl = "$old.zrl"
+            new_zrl = "$new.zrl"
+            write(old_zrl, BSDiff.read_zrle(old))
+            write(new_zrl, BSDiff.read_zrle(new))
+            index = bsindex(old_zrl)
+            for format in FORMATS
+                @show format
+                patch = @time bsdiff((old_zrl, index), new_zrl, format = format)
+                patch = @time bsdiff((old_zrl, index), new_zrl, format = format)
+                patch = @time bsdiff((old_zrl, index), new_zrl, format = format)
+                new_zrl′ = bspatch(old_zrl, patch)
+                @test read(new_zrl) == read(new_zrl′)
+            end
+            # eliminate I/O overhead
+            old_zrl_data = read(old_zrl)
+            new_zrl_data = read(new_zrl)
+            index_data = BSDiff.generate_index(old_zrl_data)
+            for PatchType in [BSDiff.EndsleyPatch, BSDiff.SparsePatch]
+                println("$PatchType generation to devnull:")
+                patch = PatchType(devnull, length(new_zrl_data))
+                @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+                @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+                @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+                println("$PatchType generation to IOBuffer:")
+                diff = sprint() do io
+                    patch = PatchType(io, length(new_zrl_data))
+                    @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+                    @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+                    @time BSDiff.generate_patch(patch, old_zrl_data, new_zrl_data, index_data)
+                end |> codeunits
+            end
+        end
         @testset "hi-level API" for format in FORMATS
             @show format
             index = bsindex(old)


### PR DESCRIPTION
This format isn't that useful on its own, but works well when the
old and new files zer zero-rle compressed before diffing.