### PR TITLE
refactor API internals

### DIFF
--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -112,7 +112,7 @@ function bsdiff(
         write(patch_io, format_magic(type))
         patch_obj = write_start(type, patch_io, old_data, new_data)
         generate_patch(patch_obj, old_data, new_data, index)
-        close(patch_obj)
+        write_finish(patch_obj)
     end
 end
 
@@ -150,7 +150,6 @@ function bspatch(
         open_write(new) do new_io
             new_io = BufferedOutputStream(new_io)
             apply_patch(patch_obj, old_data, new_io)
-            close(patch_obj)
             flush(new_io)
         end
     end

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -19,10 +19,19 @@ include("endsley.jl")
 # format names, patch types, auto detection
 
 const DEFAULT_FORMAT = :classic
-const FORMATS = Dict(
-    :classic => ClassicPatch,
-    :endsley => EndsleyPatch,
-)
+const FORMATS = Dict{Symbol,Type{<:Patch}}()
+const MAGICS = Vector{Pair{Symbol,String}}()
+
+function register_format!(format::Symbol, type::Type{<:Patch})
+    magic = format_magic(type)
+    FORMATS[format] = type
+    push!(MAGICS, format => magic)
+    sort!(MAGICS, by = ncodeunits∘last)
+    return
+end
+
+register_format!(:classic, ClassicPatch)
+register_format!(:endsley, EndsleyPatch)
 
 function patch_type(format::Symbol)
     type = get(FORMATS, format, nothing)
@@ -30,28 +39,47 @@ function patch_type(format::Symbol)
     throw(ArgumentError("unknown patch format: $format"))
 end
 
-function format_name(type::Type{<:Patch})
-    for (format, type′) in FORMATS
-        type == type′ && return format
+function detect_format(patch_io::IO)
+    data = UInt8[]
+    for (format, magic) in MAGICS
+        n = ncodeunits(magic)
+        m = n - length(data)
+        m > 0 && append!(data, read(patch_io, m))
+        view(data, 1:n) == codeunits(magic) && return format
     end
-    throw(ArgumentError("unknown patch type: $type"))
-end
-
-function detect_format(patch_io::IO, raise::Bool=false)
-    for (format, type) in FORMATS
-        mark(patch_io)
-        MAGIC = format_magic(type)
-        magic = String(read(patch_io, ncodeunits(MAGIC)))
-        reset(patch_io)
-        magic == MAGIC && return format
-    end
-    raise ? error("unrecognized patch format") : :unknown
+    return :unknown
 end
 detect_format(path::AbstractString) = open(detect_format, path)
 
+const INDEX_HEADER = "SUFFIX ARRAY\0"
+
+## some API utilities for arguments ##
+
+open_read(f::Function, file::AbstractString) = open(f, file)
+
+function open_write(f::Function, file::AbstractString)
+    try open(f, file, write=true)
+    catch
+        rm(file, force=true)
+        rethrow()
+    end
+    return file
+end
+function open_write(f::Function, file::Nothing)
+    file, io = mktemp()
+    try f(io)
+    catch
+        close(io)
+        rm(file, force=true)
+        rethrow()
+    end
+    close(io)
+    return file
+end
+
 ## high-level API (similar to the C tool) ##
 
-const AbstractStrings = Union{AbstractString,NTuple{2,AbstractString}}
+const AbstractStrings = Union{AbstractString, NTuple{2,AbstractString}}
 
 """
     bsdiff(old, new, [ patch ]; format = [ :classic | :endsley ]) -> patch
@@ -74,28 +102,18 @@ selected by with `bsdiff(old, new; format = :endsley)`.
 function bsdiff(
     old::AbstractStrings,
     new::AbstractString,
-    patch::AbstractString;
+    patch::Union{AbstractString, Nothing} = nothing;
     format::Symbol = DEFAULT_FORMAT,
 )
-    bsdiff_core(
-        patch_type(format),
-        data_and_index(old)...,
-        read(new),
-        patch, open(patch, write=true),
-    )
-end
-
-function bsdiff(
-    old::AbstractStrings,
-    new::AbstractString;
-    format::Symbol = DEFAULT_FORMAT,
-)
-    bsdiff_core(
-        patch_type(format),
-        data_and_index(old)...,
-        read(new),
-        mktemp()...,
-    )
+    type = patch_type(format)
+    old_data, index = data_and_index(old)
+    new_data = open_read(read, new)
+    open_write(patch) do patch_io
+        write(patch_io, format_magic(type))
+        patch_obj = write_start(type, patch_io, old_data, new_data)
+        generate_patch(patch_obj, old_data, new_data, index)
+        close(patch_obj)
+    end
 end
 
 """
@@ -115,18 +133,26 @@ then it will raise an error unless the patch file has the expected format.
 """
 function bspatch(
     old::AbstractString,
-    new::AbstractString,
+    new::Union{AbstractString, Nothing},
     patch::AbstractString;
     format::Symbol = :auto,
 )
-    open(patch) do patch_io
-        format == :auto && (format = detect_format(patch_io, true))
-        bspatch_core(
-            patch_type(format),
-            read(old),
-            new, open(new, write=true),
-            patch_io,
-        )
+    format == :auto || format in keys(FORMATS) ||
+        error("unknown patch format: $format")
+    old_data = open_read(read, old)
+    open_read(patch) do patch_io
+        detected = detect_format(patch_io)
+        detected == :unknown && error("unrecognized/corrupt patch file")
+        format == :auto || format == detected ||
+            error("patch has $detected format, expected $format format")
+        type = patch_type(detected)
+        patch_obj = read_start(type, patch_io)
+        open_write(new) do new_io
+            new_io = BufferedOutputStream(new_io)
+            apply_patch(patch_obj, old_data, new_io)
+            close(patch_obj)
+            flush(new_io)
+        end
     end
 end
 
@@ -135,15 +161,7 @@ function bspatch(
     patch::AbstractString;
     format::Symbol = :auto,
 )
-    open(patch) do patch_io
-        format == :auto && (format = detect_format(patch_io, true))
-        bspatch_core(
-            patch_type(format),
-            read(old),
-            mktemp()...,
-            patch_io,
-        )
-    end
+    bspatch(old, nothing, patch; format = format)
 end
 
 """
@@ -155,106 +173,33 @@ index data is saved to a temporary file whose path is returned. The path of the
 index file can be passed to `bsdiff` to speed up the diff computation by passing
 `(old, index)` as the first argument instead of just `old`.
 """
-function bsindex(old::AbstractString, index::AbstractString)
-    bsindex_core(read(old), index, open(index, write=true))
-end
-
-function bsindex(old::AbstractString)
-    bsindex_core(read(old), mktemp()...)
-end
-
-# common code for API entry points
-
-const INDEX_HEADER = "SUFFIX ARRAY\0"
-
-IndexType{T<:Integer} = Vector{T}
-
-function bsdiff_core(
-    format::Type{<:Patch},
-    old_data::AbstractVector{UInt8},
-    index::IndexType,
-    new_data::AbstractVector{UInt8},
-    patch_file::AbstractString,
-    patch_io::IO,
+function bsindex(
+    old::AbstractString,
+    index::Union{AbstractString, Nothing} = nothing,
 )
-    try
-        write(patch_io, format_magic(format))
-        patch = write_start(format, patch_io, old_data, new_data)
-        generate_patch(patch, old_data, new_data, index)
-        close(patch)
-    catch
-        close(patch_io)
-        rm(patch_file, force=true)
-        rethrow()
-    end
-    close(patch_io)
-    return patch_file
-end
-
-function bspatch_core(
-    format::Type{<:Patch},
-    old_data::AbstractVector{UInt8},
-    new_file::AbstractString,
-    new_io::IO,
-    patch_io::IO,
-)
-    new_io = BufferedOutputStream(new_io)
-    try
-        MAGIC = format_magic(format)
-        magic = String(read(patch_io, ncodeunits(MAGIC)))
-        if magic ≠ MAGIC
-            fmt = format_name(format)
-            if applicable(seekstart, patch_io)
-                seekstart(patch_io)
-                detected = detect_format(patch_io)
-                detected ≠ :unknown &&
-                    error("patch has $detected format, expected $fmt format")
-            end
-            error("corrupt $fmt patch, wrong magic: $magic")
-        end
-        patch = read_start(format, patch_io)
-        apply_patch(patch, old_data, new_io)
-        close(patch)
-    catch
-        close(new_io)
-        rm(new_file, force=true)
-        rethrow()
-    end
-    close(new_io)
-    return new_file
-end
-
-function bsindex_core(
-    old_data::AbstractVector{UInt8},
-    index_path::AbstractString,
-    index_io::IO,
-)
-    try
+    old_data = open_read(read, old)
+    open_write(index) do index_io
         write(index_io, INDEX_HEADER)
-        index = generate_index(old_data)
-        write(index_io, UInt8(sizeof(eltype(index))))
-        write(index_io, index)
-    catch
-        close(index_io)
-        rm(index_path, force=true)
-        rethrow()
+        index_data = generate_index(old_data)
+        write(index_io, UInt8(sizeof(eltype(index_data))))
+        write(index_io, index_data)
     end
-    close(index_io)
-    return index_path
 end
 
 ## loading data and index ##
 
+const IndexType{T<:Integer} = Vector{T}
+
 function data_and_index(data_path::AbstractString)
-    data = read(data_path)
+    data = open_read(read, data_path)
     data, generate_index(data)
 end
 
 function data_and_index((data_path, index_path)::NTuple{2,AbstractString})
-    data = read(data_path)
-    index = open(index_path) do index_io
+    data = open_read(read, data_path)
+    index = open_read(index_path) do index_io
         hdr = String(read(index_io, ncodeunits(INDEX_HEADER)))
-        hdr == INDEX_HEADER || error("corrupt bsdiff index")
+        hdr == INDEX_HEADER || error("corrupt bsdiff index file")
         unit = Int(read(index_io, UInt8))
         T = unit == 1 ? UInt8 :
             unit == 2 ? UInt16 :
@@ -295,7 +240,7 @@ Search for the longest prefix of new[t:end] in old.
 Uses the suffix array of old to search efficiently.
 """
 function prefix_search(
-    index::IndexType, # suffix & lcp data
+    index::IndexType, # suffix array
     old::AbstractVector{UInt8}, # old data to search in
     new::AbstractVector{UInt8}, # new data to search for
     t::Int, # search for longest match of new[t:end]

--- a/src/classic.jl
+++ b/src/classic.jl
@@ -45,19 +45,17 @@ function read_start(
     ClassicPatch(patch_io, new_size, ctrl, diff, data)
 end
 
-function Base.close(patch::ClassicPatch)
-    if iswritable(patch.ctrl.stream)
-        for stream in (patch.ctrl, patch.diff, patch.data)
-            write(stream, TranscodingStreams.TOKEN_END)
-        end
-        write_int(patch.io, patch.ctrl.stream.size)
-        write_int(patch.io, patch.diff.stream.size)
-        write_int(patch.io, patch.new_size)
-        for stream in (patch.ctrl, patch.diff, patch.data)
-            write(patch.io, resize!(stream.stream.data, stream.stream.size))
-        end
+function write_finish(patch::ClassicPatch)
+    for stream in (patch.ctrl, patch.diff, patch.data)
+        write(stream, TranscodingStreams.TOKEN_END)
     end
-    close(patch.io)
+    write_int(patch.io, patch.ctrl.stream.size)
+    write_int(patch.io, patch.diff.stream.size)
+    write_int(patch.io, patch.new_size)
+    for stream in (patch.ctrl, patch.diff, patch.data)
+        write(patch.io, resize!(stream.stream.data, stream.stream.size))
+    end
+    flush(patch.io)
 end
 
 function encode_control(

--- a/src/endsley.jl
+++ b/src/endsley.jl
@@ -27,7 +27,10 @@ function read_start(
     EndsleyPatch(TranscodingStream(codec, patch_io), new_size)
 end
 
-Base.close(patch::EndsleyPatch) = close(patch.io)
+function write_finish(patch::EndsleyPatch)
+    write(patch.io, TranscodingStreams.TOKEN_END)
+    flush(patch.io)
+end
 
 function encode_control(
     patch::EndsleyPatch,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
         dir = mktempdir()
         old_file = joinpath(dir, "old")
         new_file = joinpath(dir, "new")
-        suffix_file = joinpath(dir, "suffixes")
+        index_file = joinpath(dir, "index")
         write(old_file, "Goodbye, world.")
         write(new_file, "Hello, world!")
         for format in (nothing, :classic, :endsley)
@@ -39,13 +39,13 @@ const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
                 @test read(new_file′, String) == "Hello, world!"
             end
             @testset "bsindex API" begin
-                bsindex(old_file, suffix_file)
-                patch_file = bsdiff((old_file, suffix_file), new_file; fmt...)
+                bsindex(old_file, index_file)
+                patch_file = bsdiff((old_file, index_file), new_file; fmt...)
                 new_file′ = bspatch(old_file, patch_file; fmt...)
                 @test read(new_file′, String) == "Hello, world!"
                 # test that tempfile API makes the same file
-                suffix_file′ = bsindex(old_file)
-                @test read(suffix_file) == read(suffix_file′)
+                index_file′ = bsindex(old_file)
+                @test read(index_file) == read(index_file′)
             end
         end
         rm(dir, recursive=true, force=true)


### PR DESCRIPTION
In the process, this eliminates the `bs{diff,patch,index}_core` functions and moves the implementation of each operation into the main API entry point. It does this by using `nothing` to indicate missing arguments and by introducing `open_read` and `open_write` helpers that do the right thing when the argument is `nothing`. That makes adding support for IO handles in place of file paths uniformly much easier as well.

This also refactors the format autodetection code to avoid the need to ever rewind the patch I/O stream by looking at incrementally more of the patch data until it either matches some magic string or can't possibly match any of them.

Adds an (internal) API for format registration. If someone does want to implement a new patch format and have it hook into this package, this allows that to be done cleanly.