### PR TITLE
fix potential memory leak: don't deepcopy Bzip2{C,Dec}ompressor objects

### DIFF
--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -13,7 +13,7 @@ abstract type Patch end
 
 # specific format implementations
 
-compressor() = Bzip2Compressor()
+compressor() = Bzip2Compressor(blocksize100k=9)
 decompressor() = Bzip2Decompressor()
 
 include("classic.jl")

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -13,6 +13,9 @@ abstract type Patch end
 
 # specific format implementations
 
+compressor() = Bzip2Compressor()
+decompressor() = Bzip2Decompressor()
+
 include("classic.jl")
 include("endsley.jl")
 

--- a/src/classic.jl
+++ b/src/classic.jl
@@ -8,11 +8,11 @@ end
 function ClassicPatch(
     patch_io::IO,
     new_size::Int64 = typemax(Int64);
-    codec::Codec = Bzip2Compressor(),
+    codec = Bzip2Compressor,
 )
-    ctrl = TranscodingStream(deepcopy(codec), IOBuffer())
-    diff = TranscodingStream(deepcopy(codec), IOBuffer())
-    data = TranscodingStream(identity(codec), IOBuffer())
+    ctrl = TranscodingStream(codec(), IOBuffer())
+    diff = TranscodingStream(codec(), IOBuffer())
+    data = TranscodingStream(codec(), IOBuffer())
     ClassicPatch(patch_io, new_size, ctrl, diff, data)
 end
 
@@ -23,7 +23,7 @@ function write_start(
     patch_io::IO,
     old_data::AbstractVector{UInt8},
     new_data::AbstractVector{UInt8};
-    codec::Codec = Bzip2Compressor(),
+    codec = Bzip2Compressor,
 )
     ClassicPatch(patch_io, length(new_data), codec = codec)
 end
@@ -31,7 +31,7 @@ end
 function read_start(
     ::Type{ClassicPatch},
     patch_io::IO;
-    codec::Codec = Bzip2Decompressor(),
+    codec = Bzip2Decompressor,
 )
     ctrl_size = read_int(patch_io)
     diff_size = read_int(patch_io)
@@ -39,9 +39,9 @@ function read_start(
     ctrl_io = IOBuffer(read(patch_io, ctrl_size))
     diff_io = IOBuffer(read(patch_io, diff_size))
     data_io = IOBuffer(read(patch_io))
-    ctrl = TranscodingStream(deepcopy(codec), ctrl_io)
-    diff = TranscodingStream(deepcopy(codec), diff_io)
-    data = TranscodingStream(identity(codec), data_io)
+    ctrl = TranscodingStream(codec(), ctrl_io)
+    diff = TranscodingStream(codec(), diff_io)
+    data = TranscodingStream(codec(), data_io)
     ClassicPatch(patch_io, new_size, ctrl, diff, data)
 end
 

--- a/src/endsley.jl
+++ b/src/endsley.jl
@@ -10,21 +10,16 @@ function write_start(
     ::Type{EndsleyPatch},
     patch_io::IO,
     old_data::AbstractVector{UInt8},
-    new_data::AbstractVector{UInt8};
-    codec = Bzip2Compressor,
+    new_data::AbstractVector{UInt8},
 )
     new_size = length(new_data)
     write_int(patch_io, new_size)
-    EndsleyPatch(TranscodingStream(codec(), patch_io), new_size)
+    EndsleyPatch(TranscodingStream(compressor(), patch_io), new_size)
 end
 
-function read_start(
-    ::Type{EndsleyPatch},
-    patch_io::IO;
-    codec = Bzip2Decompressor,
-)
+function read_start(::Type{EndsleyPatch}, patch_io::IO)
     new_size = read_int(patch_io)
-    EndsleyPatch(TranscodingStream(codec(), patch_io), new_size)
+    EndsleyPatch(TranscodingStream(decompressor(), patch_io), new_size)
 end
 
 function write_finish(patch::EndsleyPatch)

--- a/src/endsley.jl
+++ b/src/endsley.jl
@@ -11,20 +11,20 @@ function write_start(
     patch_io::IO,
     old_data::AbstractVector{UInt8},
     new_data::AbstractVector{UInt8};
-    codec::Codec = Bzip2Compressor(),
+    codec = Bzip2Compressor,
 )
     new_size = length(new_data)
     write_int(patch_io, new_size)
-    EndsleyPatch(TranscodingStream(codec, patch_io), new_size)
+    EndsleyPatch(TranscodingStream(codec(), patch_io), new_size)
 end
 
 function read_start(
     ::Type{EndsleyPatch},
     patch_io::IO;
-    codec::Codec = Bzip2Decompressor(),
+    codec = Bzip2Decompressor,
 )
     new_size = read_int(patch_io)
-    EndsleyPatch(TranscodingStream(codec, patch_io), new_size)
+    EndsleyPatch(TranscodingStream(codec(), patch_io), new_size)
 end
 
 function write_finish(patch::EndsleyPatch)


### PR DESCRIPTION
These objects need to be properly constructed in order to have memory allocated for them by libbzip2. Calling deepcopy on them may have been contributing to crashes on low-memory systems, e.g. Windows CI.

Also: factor out Bzip2{C,Dec}ompressor calls into compressor/decompressor helper functions and change the default compression level to 9 (best compression).