### PR TITLE
JUILA_BSDIFF_LOWMEM: work around low memory failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,17 @@ language: julia
 os:
   - linux
   - osx
-  - windows
 julia:
   - 1.3
   - nightly
+matrix:
+  include:
+    - os: windows
+      env: JULIA_BSDIFF_LOWMEM=true
+      julia: 1.3
+    - os: windows
+      env: JULIA_BSDIFF_LOWMEM=true
+      julia: nightly
 notifications:
   email: false
 codecov: true

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -11,10 +11,20 @@ using BufferedStreams
 # specific formats defined below
 abstract type Patch end
 
-# specific format implementations
+# control over compression details
 
-compressor() = Bzip2Compressor(blocksize100k=9)
-decompressor() = Bzip2Decompressor()
+function lowmem()
+    haskey(ENV, "JULIA_BSDIFF_LOWMEM") || return false
+    val = lowercase(ENV["JULIA_BSDIFF_LOWMEM"])
+    val in ("1", "true", "t", "yes", "y") && return true
+    val in ("0", "false", "f", "no", "n") && return false
+    error("invalid value for JULIA_BSDIFF_LOWMEM: $(repr(val))")
+end
+
+compressor() = Bzip2Compressor(blocksize100k = lowmem() ? 1 : 9)
+decompressor() = Bzip2Decompressor(small = lowmem())
+
+# specific format implementations
 
 include("classic.jl")
 include("endsley.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ import bsdiff_classic_jll
 import bsdiff_endsley_jll
 import zrl_jll
 
+println("LOWMEM: ", get(ENV, "JULIA_BSDIFF_LOWMEM", "false"))
+
 const test_data = artifact"test_data"
 const FORMATS = sort!(collect(keys(BSDiff.FORMATS)))
 


### PR DESCRIPTION
This PR adds support for using the environment variable `JULIA_BSDIFF_LOWMEM` to cause `BSDiff` to use less memory for both generating and applying diffs. Ideally this shouldn't be necessary, but it seems that libbzip2 will crash in low memory systems when called repeatedly. I have tried hooking libbzip2's memory allocation into Julia's allocator which should allow it to share memory that the GC has allocated, as well as fixing various allocation issue in CodecBzip2 ([PR](https://github.com/JuliaIO/CodecBzip2.jl/pull/16)) but that doesn't fix the issue, hence this workaround. It's unclear if this is a bug in libbzip2 on in the way that CodecBzip2 calls it. If, at some point, the memory bug in one of those is fixed, we could remove this workaround.