### PR TITLE
Remove finalizer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [compat]
 ArgTools = "1"
 BufferedStreams = "1"
-CodecBzip2 = "0.6, 0.7, 0.8"
+CodecBzip2 = "0.8.5"
 SuffixArrays = "0.3, 1"
 TranscodingStreams = "0.9.5, 0.10, 0.11"
 julia = "1.6"

--- a/src/BSDiff.jl
+++ b/src/BSDiff.jl
@@ -133,7 +133,6 @@ function bspatch(
         arg_write(new) do new_io
             new_io = BufferedOutputStream(new_io)
             apply_patch(patch_obj, old_data, new_io)
-            finalize(patch_obj)
             flush(new_io)
         end
     end

--- a/src/endsley.jl
+++ b/src/endsley.jl
@@ -16,7 +16,6 @@ function write_start(
     write_int(patch_io, new_size)
     stream = TranscodingStream(compressor(), patch_io)
     patch = EndsleyPatch(stream, new_size)
-    finalizer(finalize_patch, patch)
     return patch
 end
 
@@ -25,19 +24,12 @@ function read_start(::Type{EndsleyPatch}, patch_io::IO)
     EndsleyPatch(TranscodingStream(decompressor(), patch_io), new_size)
 end
 
-function finalize_patch(patch::EndsleyPatch)
-    if patch.io isa TranscodingStream
-        # must be called to avoid leaking memory
-        TranscodingStreams.changemode!(patch.io, :close)
-    end
-end
-
 function write_finish(patch::EndsleyPatch)
     if patch.io isa TranscodingStream
         write(patch.io, TranscodingStreams.TOKEN_END)
     end
     flush(patch.io)
-    finalize(patch)
+    nothing
 end
 
 function encode_control(


### PR DESCRIPTION
The memory leak from CodecBzip2 is fixed in https://github.com/JuliaIO/CodecBzip2.jl/pull/43 so there is no need to use TranscodingStreams internals once the new version of CodecBzip2 is released.