### PR TITLE
bump version to v1.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSDiff"
 uuid = "7b188ff4-8bb6-4dee-bbe1-9b6fdde2c7c5"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 ArgTools = "0dad84c5-d112-42e6-8d28-ef12dabb789f"


### PR DESCRIPTION
diff: https://github.com/JuliaIO/BSDiff.jl/compare/f54b3abf6a8c5fbf584364f8f090b942dc7f580b...560ed2ee67a32f3cc92def3478f6b29f2fe7209d

The package now runs on julia 1.11 and no longer uses internal TranscodingStreams functions.

Minimum compat was increased for julia to v1.6 and CodecBzip2 to v0.8.5, and compat was added for SuffixArrays v1 and TranscodingStreams v0.11.

Lastly explicit use of `Int64`, `htol`, and `ltoh` was added to make the code more cross-platform.